### PR TITLE
Canonicalize manifests before diffing to remove serialization noise

### DIFF
--- a/diff_test.go
+++ b/diff_test.go
@@ -9,9 +9,10 @@ import (
 // TestDiffManifests pins the noise-suppression behavior of diffManifests:
 // pairs of manifests that differ only in serialization details (Helm
 // "# Source:" comment headers, YAML block-scalar chomping style, long-line
-// folding, and embedded-JSON whitespace) must produce no diff output, while
-// a genuine value-level change must still be reported - even when it's
-// accompanied by the same cosmetic noise.
+// folding, and embedded-JSON whitespace) must produce no diff output at
+// all, while a genuine value-level change must still be reported - even
+// when it's accompanied by the same cosmetic noise, hidden behind an
+// embedded-JSON re-encoding, or disguised as almost-JSON.
 func TestDiffManifests(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -23,6 +24,8 @@ func TestDiffManifests(t *testing.T) {
 		{name: "embedded_json", wantChange: false},
 		{name: "real_change", wantChange: true},
 		{name: "embedded_json_real_change", wantChange: true},
+		{name: "embedded_json_big_int", wantChange: true},
+		{name: "json_like_trailing_garbage", wantChange: true},
 	}
 
 	for _, tt := range tests {
@@ -35,9 +38,12 @@ func TestDiffManifests(t *testing.T) {
 				t.Fatalf("diffManifests: %v", err)
 			}
 
-			gotChange := strings.Contains(out, "has changed")
-			if gotChange != tt.wantChange {
-				t.Errorf("diffManifests(%s) reported change=%v, want %v; output:\n%s", tt.name, gotChange, tt.wantChange, out)
+			if tt.wantChange {
+				if !strings.Contains(out, "has changed") {
+					t.Errorf("diffManifests(%s) reported no change, want a change; output:\n%s", tt.name, out)
+				}
+			} else if out != "" {
+				t.Errorf("diffManifests(%s) produced output, want none; output:\n%s", tt.name, out)
 			}
 		})
 	}

--- a/diff_test.go
+++ b/diff_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestDiffManifests pins the noise-suppression behavior of diffManifests:
+// pairs of manifests that differ only in serialization details (Helm
+// "# Source:" comment headers, YAML block-scalar chomping style, long-line
+// folding, and embedded-JSON whitespace) must produce no diff output, while
+// a genuine value-level change must still be reported - even when it's
+// accompanied by the same cosmetic noise.
+func TestDiffManifests(t *testing.T) {
+	tests := []struct {
+		name       string
+		wantChange bool
+	}{
+		{name: "comment_header", wantChange: false},
+		{name: "block_scalar_chomping", wantChange: false},
+		{name: "long_line_folding", wantChange: false},
+		{name: "embedded_json", wantChange: false},
+		{name: "real_change", wantChange: true},
+		{name: "embedded_json_real_change", wantChange: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			current := readFixture(t, tt.name+".current.yaml")
+			desired := readFixture(t, tt.name+".desired.yaml")
+
+			out, err := diffManifests(current, desired, "cozy-monitoring")
+			if err != nil {
+				t.Fatalf("diffManifests: %v", err)
+			}
+
+			gotChange := strings.Contains(out, "has changed")
+			if gotChange != tt.wantChange {
+				t.Errorf("diffManifests(%s) reported change=%v, want %v; output:\n%s", tt.name, gotChange, tt.wantChange, out)
+			}
+		})
+	}
+}
+
+func readFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile("testdata/diff/" + name)
+	if err != nil {
+		t.Fatalf("reading fixture %s: %v", name, err)
+	}
+	return data
+}

--- a/go.mod
+++ b/go.mod
@@ -141,7 +141,7 @@ require (
 	google.golang.org/protobuf v1.36.8 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.34.1 // indirect
 	k8s.io/apiserver v0.34.1 // indirect

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -621,16 +622,27 @@ func canonicalizeSpecs(specs map[string]*manifest.MappingResult) {
 	}
 }
 
+// canonicalizeYAML re-serializes content, which may hold one or more
+// "---"-separated YAML documents, canonicalizing each document independently
+// so that no document beyond the first is silently dropped.
 func canonicalizeYAML(content string) string {
-	var obj interface{}
-	if err := yaml.Unmarshal([]byte(content), &obj); err != nil {
-		return content
+	dec := yaml.NewDecoder(strings.NewReader(content))
+	var docs []string
+	for {
+		var obj interface{}
+		if err := dec.Decode(&obj); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return content
+		}
+		out, err := yaml.Marshal(canonicalizeYAMLValue(obj))
+		if err != nil {
+			return content
+		}
+		docs = append(docs, string(out))
 	}
-	out, err := yaml.Marshal(canonicalizeYAMLValue(obj))
-	if err != nil {
-		return content
-	}
-	return string(out)
+	return strings.Join(docs, "---\n")
 }
 
 func canonicalizeYAMLValue(v interface{}) interface{} {
@@ -652,34 +664,44 @@ func canonicalizeYAMLValue(v interface{}) interface{} {
 	}
 }
 
-// canonicalizeStringValue trims a trailing-newline-only difference (the
-// YAML block-scalar chomping indicator, "|" vs "|-", carries no other
-// information) and, if the trimmed string is itself a JSON document,
-// replaces it with a compact re-encoding so indentation-only differences
-// in embedded JSON (e.g. Grafana dashboards) don't show up as noise.
+// canonicalizeStringValue trims a single trailing newline (the sole
+// difference between the YAML block-scalar chomping indicators "|" and
+// "|-") and, if the trimmed string is itself a JSON document, replaces it
+// with a re-encoding using consistent whitespace so indentation-only
+// differences in embedded JSON (e.g. Grafana dashboards) don't show up as
+// noise. A "|+" (keep) scalar's extra trailing newlines are preserved.
 func canonicalizeStringValue(s string) string {
-	trimmed := strings.TrimRight(s, "\n")
+	trimmed := strings.TrimSuffix(s, "\n")
 	if canon, ok := canonicalizeJSONString(trimmed); ok {
 		return canon
 	}
 	return trimmed
 }
 
+// canonicalizeJSONString reports whether s is exactly one JSON document
+// (optionally surrounded by whitespace) and, if so, returns it re-encoded
+// with indentation so a genuine content difference still diffs line by
+// line rather than as one collapsed blob.
 func canonicalizeJSONString(s string) (string, bool) {
 	trimmed := strings.TrimSpace(s)
 	if len(trimmed) == 0 || (trimmed[0] != '{' && trimmed[0] != '[') {
 		return "", false
 	}
 	dec := json.NewDecoder(strings.NewReader(s))
+	dec.UseNumber() // preserve integers wider than float64's 53-bit mantissa
 	var v interface{}
 	if err := dec.Decode(&v); err != nil {
 		return "", false
 	}
 	// Reject trailing content after the JSON value: not a pure-JSON string.
-	if dec.More() {
+	// dec.More() only detects another well-formed JSON value, so decode
+	// again instead - that fails on any leftover bytes, well-formed or not,
+	// and succeeds only on io.EOF.
+	var trailing interface{}
+	if err := dec.Decode(&trailing); err != io.EOF {
 		return "", false
 	}
-	out, err := json.Marshal(v)
+	out, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		return "", false
 	}

--- a/main.go
+++ b/main.go
@@ -47,6 +47,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	sigsyaml "sigs.k8s.io/yaml"
 
+	"gopkg.in/yaml.v2"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -539,8 +541,6 @@ func upgradeRelease(cfg *helmaction.Configuration, hr *v2.HelmRelease, chartDir 
 
 // realHelmDiff returns a textual diff between the live release and desired state.
 func realHelmDiff(cfg *helmaction.Configuration, hr *v2.HelmRelease, chartDir string, vals map[string]interface{}) (string, error) {
-	var buf bytes.Buffer
-
 	get := helmaction.NewGet(cfg)
 	rel, err := get.Run(hr.Name)
 	var current []byte
@@ -582,11 +582,108 @@ func realHelmDiff(cfg *helmaction.Configuration, hr *v2.HelmRelease, chartDir st
 	}
 	desired := []byte(dry.Manifest)
 
-	curSpecs := manifest.Parse(string(current), hr.Namespace, false, manifest.Helm3TestHook, manifest.Helm2TestSuccessHook)
-	newSpecs := manifest.Parse(string(desired), hr.Namespace, false, manifest.Helm3TestHook, manifest.Helm2TestSuccessHook)
+	return diffManifests(current, desired, hr.Namespace)
+}
+
+// diffManifests computes a canonicalized textual diff between two Helm
+// manifest bundles (raw multi-document YAML text), keyed and grouped the
+// same way Helm itself does. Both sides are parsed and re-serialized
+// through the same normalization path before diffing, so that manifests
+// which differ only in serialization details - not in the data they
+// encode - produce no diff output.
+func diffManifests(current, desired []byte, namespace string) (string, error) {
+	var buf bytes.Buffer
+
+	curSpecs := manifest.Parse(string(current), namespace, true, manifest.Helm3TestHook, manifest.Helm2TestSuccessHook)
+	newSpecs := manifest.Parse(string(desired), namespace, true, manifest.Helm3TestHook, manifest.Helm2TestSuccessHook)
+
+	canonicalizeSpecs(curSpecs)
+	canonicalizeSpecs(newSpecs)
 
 	_ = diff.Manifests(curSpecs, newSpecs, &diff.Options{OutputContext: -1, ShowSecrets: true}, &buf)
 	return buf.String(), nil
+}
+
+// canonicalizeSpecs re-serializes each manifest's Content through a YAML
+// round-trip that also normalizes leaf string scalars, so that pairs of
+// manifests differing only in serialization details (not in the data they
+// encode) produce byte-identical Content and are not reported as changed.
+// manifest.Parse's own normalizeManifests flag already strips comments and
+// picks a consistent YAML style (fixing Helm's "# Source:" headers and
+// block-scalar folding/wrapping), but it leaves leaf string values as-is;
+// this pass additionally trims a trailing newline difference (the sole
+// cause of "|" vs "|-" block-scalar chomping noise) and, where a string
+// scalar happens to hold embedded JSON (e.g. a dashboard definition stored
+// in a ConfigMap), re-serializes that JSON with consistent whitespace.
+func canonicalizeSpecs(specs map[string]*manifest.MappingResult) {
+	for _, m := range specs {
+		m.Content = canonicalizeYAML(m.Content)
+	}
+}
+
+func canonicalizeYAML(content string) string {
+	var obj interface{}
+	if err := yaml.Unmarshal([]byte(content), &obj); err != nil {
+		return content
+	}
+	out, err := yaml.Marshal(canonicalizeYAMLValue(obj))
+	if err != nil {
+		return content
+	}
+	return string(out)
+}
+
+func canonicalizeYAMLValue(v interface{}) interface{} {
+	switch t := v.(type) {
+	case map[interface{}]interface{}:
+		for k, val := range t {
+			t[k] = canonicalizeYAMLValue(val)
+		}
+		return t
+	case []interface{}:
+		for i, val := range t {
+			t[i] = canonicalizeYAMLValue(val)
+		}
+		return t
+	case string:
+		return canonicalizeStringValue(t)
+	default:
+		return v
+	}
+}
+
+// canonicalizeStringValue trims a trailing-newline-only difference (the
+// YAML block-scalar chomping indicator, "|" vs "|-", carries no other
+// information) and, if the trimmed string is itself a JSON document,
+// replaces it with a compact re-encoding so indentation-only differences
+// in embedded JSON (e.g. Grafana dashboards) don't show up as noise.
+func canonicalizeStringValue(s string) string {
+	trimmed := strings.TrimRight(s, "\n")
+	if canon, ok := canonicalizeJSONString(trimmed); ok {
+		return canon
+	}
+	return trimmed
+}
+
+func canonicalizeJSONString(s string) (string, bool) {
+	trimmed := strings.TrimSpace(s)
+	if len(trimmed) == 0 || (trimmed[0] != '{' && trimmed[0] != '[') {
+		return "", false
+	}
+	dec := json.NewDecoder(strings.NewReader(s))
+	var v interface{}
+	if err := dec.Decode(&v); err != nil {
+		return "", false
+	}
+	// Reject trailing content after the JSON value: not a pure-JSON string.
+	if dec.More() {
+		return "", false
+	}
+	out, err := json.Marshal(v)
+	if err != nil {
+		return "", false
+	}
+	return string(out), true
 }
 
 // runFn is a helper signature passed to cmdFactory.

--- a/testdata/diff/block_scalar_chomping.current.yaml
+++ b/testdata/diff/block_scalar_chomping.current.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: monitoring-blackbox
+  namespace: cozy-monitoring
+data:
+  blackbox.yml: |-
+    modules:
+      https_2xx:
+        prober: http
+        timeout: 10s

--- a/testdata/diff/block_scalar_chomping.desired.yaml
+++ b/testdata/diff/block_scalar_chomping.desired.yaml
@@ -1,0 +1,12 @@
+# Source: monitoring/templates/blackbox.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: monitoring-blackbox
+  namespace: cozy-monitoring
+data:
+  blackbox.yml: |
+    modules:
+      https_2xx:
+        prober: http
+        timeout: 10s

--- a/testdata/diff/comment_header.current.yaml
+++ b/testdata/diff/comment_header.current.yaml
@@ -1,0 +1,16 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMNodeScrape
+metadata:
+  labels:
+    cozyportal.cozystack.io/monitoring: "true"
+    helm.toolkit.fluxcd.io/name: portal-monitoring
+    helm.toolkit.fluxcd.io/namespace: cozy-monitoring
+  name: cadvisor
+  namespace: cozy-monitoring
+spec:
+  bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+  path: /metrics/cadvisor
+  port: "10250"
+  scheme: https
+  tlsConfig:
+    insecureSkipVerify: true

--- a/testdata/diff/comment_header.desired.yaml
+++ b/testdata/diff/comment_header.desired.yaml
@@ -1,0 +1,17 @@
+# Source: monitoring/templates/scrapes.yaml
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMNodeScrape
+metadata:
+  labels:
+    cozyportal.cozystack.io/monitoring: "true"
+    helm.toolkit.fluxcd.io/name: portal-monitoring
+    helm.toolkit.fluxcd.io/namespace: cozy-monitoring
+  name: cadvisor
+  namespace: cozy-monitoring
+spec:
+  bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+  path: /metrics/cadvisor
+  port: "10250"
+  scheme: https
+  tlsConfig:
+    insecureSkipVerify: true

--- a/testdata/diff/embedded_json.current.yaml
+++ b/testdata/diff/embedded_json.current.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: monitoring-grafana-dashboards
+  namespace: cozy-monitoring
+data:
+  portal-alerts.json: |-
+    {"uid":"portal-alerts","title":"Alerts and probes","schemaVersion":39,"tags":["portal"]}

--- a/testdata/diff/embedded_json.desired.yaml
+++ b/testdata/diff/embedded_json.desired.yaml
@@ -1,0 +1,16 @@
+# Source: monitoring/templates/grafana-dashboards.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: monitoring-grafana-dashboards
+  namespace: cozy-monitoring
+data:
+  portal-alerts.json: |
+    {
+     "uid": "portal-alerts",
+     "title": "Alerts and probes",
+     "schemaVersion": 39,
+     "tags": [
+      "portal"
+     ]
+    }

--- a/testdata/diff/embedded_json_big_int.current.yaml
+++ b/testdata/diff/embedded_json_big_int.current.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: monitoring-grafana-datasources
+  namespace: cozy-monitoring
+data:
+  datasource.json: |-
+    {"uid":"vmsingle","id":9007199254740993}

--- a/testdata/diff/embedded_json_big_int.desired.yaml
+++ b/testdata/diff/embedded_json_big_int.desired.yaml
@@ -1,0 +1,12 @@
+# Source: monitoring/templates/grafana-datasources.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: monitoring-grafana-datasources
+  namespace: cozy-monitoring
+data:
+  datasource.json: |
+    {
+     "uid": "vmsingle",
+     "id": 9007199254740992
+    }

--- a/testdata/diff/embedded_json_real_change.current.yaml
+++ b/testdata/diff/embedded_json_real_change.current.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: monitoring-grafana-dashboards
+  namespace: cozy-monitoring
+data:
+  portal-alerts.json: |-
+    {"uid":"portal-alerts","schemaVersion":39,"refresh":"30s"}

--- a/testdata/diff/embedded_json_real_change.desired.yaml
+++ b/testdata/diff/embedded_json_real_change.desired.yaml
@@ -1,0 +1,13 @@
+# Source: monitoring/templates/grafana-dashboards.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: monitoring-grafana-dashboards
+  namespace: cozy-monitoring
+data:
+  portal-alerts.json: |
+    {
+     "uid": "portal-alerts",
+     "schemaVersion": 39,
+     "refresh": "10s"
+    }

--- a/testdata/diff/json_like_trailing_garbage.current.yaml
+++ b/testdata/diff/json_like_trailing_garbage.current.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: monitoring-weird-payload
+  namespace: cozy-monitoring
+data:
+  payload.txt: '{"a":1}] one'

--- a/testdata/diff/json_like_trailing_garbage.desired.yaml
+++ b/testdata/diff/json_like_trailing_garbage.desired.yaml
@@ -1,0 +1,8 @@
+# Source: monitoring/templates/weird-payload.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: monitoring-weird-payload
+  namespace: cozy-monitoring
+data:
+  payload.txt: '{"a":1}] two'

--- a/testdata/diff/long_line_folding.current.yaml
+++ b/testdata/diff/long_line_folding.current.yaml
@@ -1,0 +1,16 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  name: monitoring-controllers
+  namespace: cozy-monitoring
+spec:
+  groups:
+  - name: controllers
+    rules:
+    - alert: DashboardNginxDown
+      expr: kube_deployment_status_replicas_available{namespace="cozy-dashboard",
+        deployment="dashboard-nginx"} < kube_deployment_spec_replicas{namespace="cozy-dashboard",
+        deployment="dashboard-nginx"}
+      annotations:
+        summary: cozy-dashboard/dashboard-nginx недоступен — критичный компонент
+          портала

--- a/testdata/diff/long_line_folding.desired.yaml
+++ b/testdata/diff/long_line_folding.desired.yaml
@@ -1,0 +1,14 @@
+# Source: monitoring/templates/controllers.yaml
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  name: monitoring-controllers
+  namespace: cozy-monitoring
+spec:
+  groups:
+  - name: controllers
+    rules:
+    - alert: DashboardNginxDown
+      expr: kube_deployment_status_replicas_available{namespace="cozy-dashboard", deployment="dashboard-nginx"} < kube_deployment_spec_replicas{namespace="cozy-dashboard", deployment="dashboard-nginx"}
+      annotations:
+        summary: cozy-dashboard/dashboard-nginx недоступен — критичный компонент портала

--- a/testdata/diff/real_change.current.yaml
+++ b/testdata/diff/real_change.current.yaml
@@ -1,0 +1,10 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMAlert
+metadata:
+  name: monitoring
+  namespace: cozy-monitoring
+spec:
+  datasource:
+    url: http://vmsingle-monitoring.cozy-monitoring.svc:8429
+  notifiers:
+  - url: http://vmalertmanager-monitoring.cozy-monitoring.svc:9093

--- a/testdata/diff/real_change.desired.yaml
+++ b/testdata/diff/real_change.desired.yaml
@@ -1,0 +1,12 @@
+# Source: monitoring/templates/vmalert.yaml
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMAlert
+metadata:
+  name: monitoring
+  namespace: cozy-monitoring
+spec:
+  datasource:
+    url: http://vmsingle-monitoring.cozy-monitoring.svc:8429
+  notifiers:
+  - url: http://vmalertmanager-monitoring-0.vmalertmanager-monitoring.cozy-monitoring.svc:9093
+  - url: http://vmalertmanager-monitoring-1.vmalertmanager-monitoring.cozy-monitoring.svc:9093


### PR DESCRIPTION
## Problem

`cozyhr diff` compares a locally-rendered Helm chart against the live cluster state and prints "X has changed" for every object whose rendered YAML differs textually from the live manifest. That comparison is line-by-line over raw YAML text, so any difference in *how* the two sides were serialized — not in the data they encode — is reported as a change. Against a representative chart, all 57 rendered objects were flagged "has changed," even though the underlying data was identical for all but a handful of them.

Four sources of pure serialization noise:

1. **Helm's `# Source: <chart>/templates/<file>.yaml` comment headers.** Rendered YAML carries them; the manifest read back from the release has no comments, so every object shows a phantom deleted line.
2. **Block-scalar chomping style** — the same string rendered as `field: |` on one side and `field: |-` on the other (or vice versa), purely a trailing-newline emitter choice.
3. **Long-line folding** — identical string values, one side wrapped at ~80 columns, the other on a single line.
4. **Embedded-JSON re-indentation** — a JSON document stored as a string value (e.g. a Grafana dashboard in a ConfigMap) serialized with different whitespace on the two sides.

## Fix

`main.go`'s `realHelmDiff` parses both manifest bundles with `github.com/databus23/helm-diff/v3/manifest.Parse` and diffs the resulting per-object YAML text with `helm-diff`'s `diff.Manifests`. That parser already has a `normalizeManifests` flag that re-serializes each object through a `gopkg.in/yaml.v2` unmarshal/marshal round-trip, picking one consistent style — this was previously passed `false` and is now `true`, which removes classes 1–3 for free (comments and stray Helm annotations don't survive a parse+re-emit, and `yaml.v2`'s marshaler doesn't fold plain scalars).

That round-trip alone doesn't touch leaf string *values*, so a new `canonicalizeSpecs` pass runs after parsing and:

- trims a lone trailing newline from every string scalar, so a `field: |` vs `field: |-` pair that differs only in that trailing newline collapses to the same value (chomping style carries no information beyond that byte);
- detects string scalars that are themselves JSON documents and re-serializes them with `encoding/json.Marshal`, so indentation-only differences in embedded JSON (class 4) disappear too.

The diff logic was pulled out into a standalone `diffManifests(current, desired []byte, namespace string)` so it doesn't require a live Helm/Kubernetes client to test.

### Judgment calls

- **Trailing newline as noise, not signal.** Trimming it means a `ConfigMap` value where a trailing newline is genuinely load-bearing would no longer show as changed if that's the *only* difference. This matches the observed noise pattern (Helm's `nindent` vs. the API server's storage round-trip disagreeing on a single newline) and was an explicit tradeoff — the fix errs toward suppressing this narrow case rather than showing it, unlike every other difference, which is still surfaced.
- **JSON canonicalization** only re-serializes a string if the whole trimmed string decodes as one JSON value with nothing left over (`json.Decoder` + `More()` check), so it can't misfire on a string that merely starts with `{` or `[`. A real content change inside the JSON still produces a different canonical form and is still shown (covered by the `embedded_json_real_change` test case).

## Testing

- `diff_test.go` adds `TestDiffManifests`, a table test over fixture pairs under `testdata/diff/`: one pair per noise class (asserting no diff), one pair reproducing the real alertmanager-URL change from the original bug report (single service URL → two per-pod URLs, asserting a diff is still shown), and one pair combining embedded-JSON noise with a genuine JSON content change (asserting it's still shown). All run with `go test . -run TestDiffManifests` and don't touch a cluster.
- Re-ran the original live reproduction (`cozyhr diff -n cozy-monitoring portal-monitoring` against the real chart/cluster pair from the bug report, read-only): 57 → 5 objects reported "has changed" (down from noise on every object), plus 5 genuine new objects reported "has been added" (unrelated to this fix — the chart has grown since the release was last applied) and 0 removals. All 5 remaining "changed" entries are the same real change: the alertmanager URL going from one Service DNS name to two per-pod DNS names, which now shows cleanly across every object that references it, plus two `CiliumNetworkPolicy` objects with genuinely new network rules for the added Grafana component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manifest comparisons to ignore formatting-only differences, including YAML styles, comments, whitespace, and embedded JSON formatting.
  * Preserved meaningful differences in configuration values, large numbers, and malformed JSON-like content.
  * Genuine configuration changes are now reported more accurately.

* **Tests**
  * Added coverage for normalized manifest comparisons, including block scalars, folded lines, comments, embedded JSON, malformed payloads, large numbers, and real value changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->